### PR TITLE
Update WAO height_name within site_info.json

### DIFF
--- a/openghg_defs/data/site_info.json
+++ b/openghg_defs/data/site_info.json
@@ -3169,7 +3169,7 @@
   "WAO": {
     "ICOS": {
       "height": ["10m"],
-      "height_name": ["20magl"],
+      "height_name": {"10m": ["10magl", "20magl"]},
       "height_station_masl": 17.0,
       "latitude": 52.95,
       "long_name": "WAO",
@@ -3179,7 +3179,7 @@
     },
     "UCAM": {
       "height": ["10m"],
-      "height_name": ["20magl"],
+      "height_name": {"10m": ["10magl", "20magl"]},
       "height_station_masl": 17.0,
       "latitude": 52.95042,
       "long_name": "Weybourne Observatory, UK",
@@ -3187,7 +3187,7 @@
     },
     "UEA": {
       "height": ["10m"],
-      "height_name": ["20magl"],
+      "height_name": {"10m": ["10magl", "20magl"]},
       "height_station_masl": 17.0,
       "latitude": 52.95042,
       "long_name": "Weybourne Observatory, UK",


### PR DESCRIPTION
Proposing WAO height_name update to include new agreed dictionary format. This is allow mapping of NAME footprints with both "20magl" and "10magl" heights to be mapped to "10m" inlet value.

See also current PR on openghg for interpreting these input values: https://github.com/openghg/openghg/pull/648

Note: originally we discussed that this should be "21magl" but looking at the WAO files on BP1 this seems to be labelled as "20magl" which is why I included this change instead. If this is incorrect though, we can update this to be "21magl".