### PR TITLE
Update BSD height_name to allow "248magl" and "250magl" to be options for "248m" inlet

### DIFF
--- a/openghg_defs/data/site_info.json
+++ b/openghg_defs/data/site_info.json
@@ -406,7 +406,7 @@
         }
       ],
       "height": ["248m", "108m", "42m"],
-      "height_name": ["248magl", "108magl", "42magl"],
+      "height_name": {"248m": ["248magl", "250magl"], "108m": ["108magl"], "42m": ["42magl"]},
       "height_station_masl": 382,
       "latitude": 54.35861,
       "long_name": "Bilsdale, UK",


### PR DESCRIPTION
For BSD site, we have some footprints which have a height of "250magl" and some at "248magl". This update is to allow "248m" to be used to find both "250magl" and "248magl" footprints.

This updates has only been applied to "AGAGE" not "NOAA" network as this seems to be applicable to some footprints for co2 data generated for AGAGE.