### PR TITLE
Added "LONDON" as IMP network

### DIFF
--- a/openghg_defs/data/site_info.json
+++ b/openghg_defs/data/site_info.json
@@ -1409,14 +1409,15 @@
   },
 
   "IMP": {
+    "LONDON": {
       "height": ["26m"],
       "height_name": ["26magl"],
       "height_station_masl": 36.0,
       "latitude": 51.4988,
       "long_name": "Imperial College London, London, UK",
       "longitude": -0.1749
-    },
-
+    }
+  },
   "INU": {
     "EC": {
       "height": ["10m"],


### PR DESCRIPTION
In response to issue #30 I have added "LONDON" as the network for the Imperial College London site. Although not part of any official network this can serve as a placeholder for the network. 

Closes #30 