### PR TITLE
Aligned height and height_name for TAC

### DIFF
--- a/openghg_defs/data/site_info.json
+++ b/openghg_defs/data/site_info.json
@@ -2993,7 +2993,7 @@
   "TAC": {
     "DECC": {
       "height": ["185m", "54m", "100m"],
-      "height_name": ["185magl", "100magl", "54magl"],
+      "height_name": ["185magl", "54magl", "100magl"],
       "height_station_masl": 64,
       "latitude": 52.51882,
       "long_name": "Tacolneston Tower, UK",


### PR DESCRIPTION
tac height and height name were in different orders:
`["185m", "54m", "100m"]` and `["185magl", "100magl", "54magl"]`
This meant that the tutorial did not load correctly, as it was fetching 54m obs but 100magl footprints. Changing the order so that they are aligned which solves tutorial problem

before: 
`extract_height_name("TAC", "decc", "54m")` returns "100magl"

expected behaviour, and behaviour after correcting:
`extract_height_name("TAC", "decc", "54m")` returns "54magl"